### PR TITLE
Fix speling misstakes

### DIFF
--- a/etre-dev-web/quelques-trucs-a-savoir.md
+++ b/etre-dev-web/quelques-trucs-a-savoir.md
@@ -2,7 +2,7 @@
 
 Quelques petits trucs à savoir, ou à faire savoir à votre entourage ; ou comment tordre le cou à certains préjugés tenaces.
 
-1. **C'est un vrai métier, pas un truc de glandeur.** C'est pas pasque vous êtes à longueur de journée derrière votre ordinateur que vous ne travaillez pas : en fait, c'est l'inverse. Progressivement, ça rentre dans les moeurs et tant mieux pour vous. Ça l'était beaucoup moins quand j'ai commencé. ;)
+1. **C'est un vrai métier, pas un truc de glandeur.** C'est pas pasque vous êtes à longueur de journée derrière votre ordinateur que vous ne travaillez pas : en fait, c'est l'inverse. Progressivement, ça rentre dans les mœurs et tant mieux pour vous. Ça l'était beaucoup moins quand j'ai commencé. ;)
 
 2. **Être curieux est le seul vrai prérequis.** Être développeur web (ou développeur tout court), c'est ne jamais arrêter d'apprendre, remettre en question ses connaissances, courir après les nouveautés. Si vous estimez que vos connaissances actuelles vous suffisent… ben ça va pas suffire longtemps.
 
@@ -10,4 +10,4 @@ Quelques petits trucs à savoir, ou à faire savoir à votre entourage ; ou comm
 
 4. **Devenez bilingue. Au moins un peu.** Dans notre métier, toutes les publications ou presque sont en anglais. Je ne dis pas qu'il n'y a pas de bons blogs ou sites de références en français, mais toutes les spécifications et la plupart des documentations sont en anglais, c'est comme ça. Bien sûr, être parfaitement bilingue en anglais est un atout, mais ce n'est pas forcément nécéssaire : soyez capables de lire (et comprendre) des textes techniques en anglais, et de formuler vos problèmes dans un anglais plus ou moins correct, au cas où vous devriez en discuter sur des forums.
 
-5. **Vous n'êtes pas un technicien en informatique.** *Celle-la, elle est pour vos proches*. Oui, forcément, vous vous y "connaissez" en informatique : vous êtes "*tout le temps sur votre ordinateur*". Ca ne fait pas de vous un service après-vente. Soyez ferme et ne cédez jamais : on sait comment ça commence ("*y a un truc qui cloche sur ma machine, tu peux y jeter un œil ?*"), on sait jamais comment ça fini. Chacun son métier, après tout.
+5. **Vous n'êtes pas un technicien en informatique.** *Celle-la, elle est pour vos proches*. Oui, forcément, vous vous y "connaissez" en informatique : vous êtes "*tout le temps sur votre ordinateur*". Ca ne fait pas de vous un service après-vente. Soyez ferme et ne cédez jamais : on sait comment ça commence ("*y a un truc qui cloche sur ma machine, tu peux y jeter un œil ?*"), on sait jamais comment ça finit. Chacun son métier, après tout.


### PR DESCRIPTION
Le « t » en plus, c’est parce qu’il manquait un « t ». Le « œ », c’est pour faire mon chiant. :smile: 

…

Bon, et aussi parce que cette ligature a valeur orthographique et que l’omettre [est une fôte d’aurtograf](https://fr.wiktionary.org/wiki/moeurs).

Bisous ! :kissing_smiling_eyes: 
